### PR TITLE
Add support for stdin / stdout

### DIFF
--- a/src/gwsocket.c
+++ b/src/gwsocket.c
@@ -57,6 +57,9 @@ static struct option long_opts[] = {
   {"origin"         , required_argument , 0 ,  0  } ,
   {"pipein"         , required_argument , 0 ,  0  } ,
   {"pipeout"        , required_argument , 0 ,  0  } ,
+  {"std"            , no_argument       , 0 ,  0  } ,
+  {"stdin"          , no_argument       , 0 ,  0  } ,
+  {"stdout"         , no_argument       , 0 ,  0  } ,
 #if HAVE_LIBSSL
   {"ssl-cert"       , required_argument , 0 ,  0  } ,
   {"ssl-key"        , required_argument , 0 ,  0  } ,
@@ -94,6 +97,9 @@ cmd_help (void)
   "                             from on the given path/file.\n"
   "  --pipeout=<path/file>    - Creates a named pipe (FIFO) that writes\n"
   "                             to on the given path/file.\n"
+  "  --std                    - Enable --stdin and --stdout.\n"
+  "  --stdin                  - Send stdin to the websocket.\n"
+  "  --stdout                 - Send received websocket data to stdout.\n"
   "  --strict                 - Parse messages using strict mode. See\n"
   "                             man page for more details.\n"
   "  --ssl-cert=<cert.crt>    - Path to SSL certificate.\n"
@@ -217,6 +223,14 @@ parse_long_opt (const char *name, const char *oarg)
   if (!strcmp ("ssl-key", name))
     ws_set_config_sslkey (oarg);
 #endif
+  if (!strcmp ("std", name)) {
+    ws_set_config_stdin (1);
+    ws_set_config_stdout (1);
+  }
+  if (!strcmp ("stdin", name))
+    ws_set_config_stdin (1);
+  if (!strcmp ("stdout", name))
+    ws_set_config_stdout (1);
 }
 
 /* Read the user's supplied command line options. */

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -288,6 +288,8 @@ typedef struct WSConfig_
   int strict;
   int max_frm_size;
   int use_ssl;
+  int use_stdin;
+  int use_stdout;
 } WSConfig;
 
 /* A WebSocket Instance */
@@ -333,6 +335,8 @@ void ws_set_config_pipeout (const char *pipeout);
 void ws_set_config_port (const char *port);
 void ws_set_config_sslcert (const char *sslcert);
 void ws_set_config_sslkey (const char *sslkey);
+void ws_set_config_stdin (int use_stdin);
+void ws_set_config_stdout (int use_stdout);
 void ws_set_config_strict (int strict);
 void ws_start (WSServer * server);
 void ws_stop (WSServer * server);


### PR DESCRIPTION
By default named pipes are used for io, this patch adds the option to use
stdin / stdout as well. This allows e.g.

./gwsocket --std > log.txt
tail -F /var/log/syslog | ./gwsocket --std

--stdin and --stdout are added for fine grained control.

closes https://github.com/allinurl/gwsocket/issues/7

todo: man page / README updates

(same as the previous one with some tabs versus 2 spaces changes)