### PR TITLE
Add "addr" to parse_long_opt unction

### DIFF
--- a/src/gwsocket.c
+++ b/src/gwsocket.c
@@ -203,6 +203,8 @@ onmessage (WSPipeOut * pipeout, WSClient * client)
 static void
 parse_long_opt (const char *name, const char *oarg)
 {
+  if (!strcmp ("addr", name)
+    ws_set_config_host (oarg);
   if (!strcmp ("echo-mode", name))
     ws_set_config_echomode (1);
   if (!strcmp ("max-frame-size", name))


### PR DESCRIPTION
Command Line Option --addr is currently ignored.