### PR TITLE
Strict protocol parsing #30

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -2567,9 +2567,9 @@ handle_strict_fifo (WSServer * server) {
   ptr += unpack_uint32 (ptr, &size);
 
   if (validate_fifo_packet (listener, type, size) == 1) {
-    close (pi->fd);
-    clear_fifo_packet (pi);
-    ws_openfifo_in (pi);
+    for(int i = 0; i < HDR_SIZE - 1; i++)
+      pi->hdr[i] = pi->hdr[i+1];
+    pi->hlen--;
     return;
   }
 


### PR DESCRIPTION
When wrong header for strict protocol is received, current implementation is throwing away complete header (12 bytes) from incoming buffer. Suggested implementation is throwing away just 1 byte and will search again for valid header.
For more details, please take a look [here](https://github.com/allinurl/gwsocket/issues/30)