### PR TITLE
fix: correct occured to occurred typo in error message

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -32,7 +32,7 @@
 
 #define FATAL(fmt, ...) do {                                                  \
   fprintf (stderr, "\nFatal error has occurred");                             \
-  fprintf (stderr, "\nError occured at: %s - %s - %d\n", __FILE__,            \
+  fprintf (stderr, "\nError occurred at: %s - %s - %d\n", __FILE__,            \
            __FUNCTION__, __LINE__);                                           \
   fprintf (stderr, fmt, ##__VA_ARGS__);                                       \
   fprintf (stderr, "\n\n");                                                   \


### PR DESCRIPTION
Corrects the typo `occured` → `occurred` in the `FATAL` macro error message in `src/log.h:35`.

1 file, 1 line change.